### PR TITLE
Update ErrorHandler to not need -fbackslash.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(fortran_error_handler)
 enable_language(Fortran)
 
 if(CMAKE_Fortran_COMPILER_ID MATCHES "GNU")
-    set(FLAGS "-O3 -fcheck=all -fbackslash -ffpe-trap=zero,invalid,overflow")
+    set(FLAGS "-O3 -fcheck=all -ffpe-trap=zero,invalid,overflow")
 endif()
 if(CMAKE_Fortran_COMPILER_ID MATCHES "Intel")
-    set(FLAGS "/O3 /fpe:0 /assume:bscc")
+    set(FLAGS "/O3 /fpe:0")
 endif()
 
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${FLAGS}")

--- a/README.md
+++ b/README.md
@@ -31,15 +31,14 @@ Or you can clone the repo and build the library yourself using fpm:
 ```bash
 $ git clone https://github.com/samharrison7/fortran-error-handler
 $ cd fortran-error-handler
-$ fpm build --flag="-fbackslash"
+$ fpm build
 ```
 
-A static library (e.g. `libfeh.a` on Linux) and `.mod` files will be generated in the `build` directory for you to use. An example executable (using `example/example_usage.f90`) will also be generated. Running `fpm test` will run tests (using `tests/run_tests.f90`) for the framework. The `-fbackslash` flag is a GFortran flag to enable coloured terminal output, and is only needed if the `bashColors` option is `.true.` (default). The equivalent `ifort` flag is `/assume:bscc`.
-
+A static library (e.g. `libfeh.a` on Linux) and `.mod` files will be generated in the `build` directory for you to use. An example executable (using `example/example_usage.f90`) will also be generated. Running `fpm test` will run tests (using `tests/run_tests.f90`) for the framework. 
 You can also get fpm to install the Fortran Error Handler locally (e.g. to `/home/<user>/.local`):
 
 ```bash
-$ fpm install --flag="-fbackslash"
+$ fpm install
 ```
 
 Fpm can easily be installed using Conda: `conda install -c conda-forge fpm`.

--- a/meson.build
+++ b/meson.build
@@ -3,10 +3,10 @@ project('feh', 'fortran', meson_version: '>=0.50')
 # Compiler flags
 flags = ''
 if meson.get_compiler('fortran').get_id() == 'gcc'
-    flags = ['-fbackslash', '-fbacktrace']
+    flags = ['-fbacktrace']
 endif
 if meson.get_compiler('fortran').get_id() == 'intel'
-    flags = ['-assume', 'bscc', '-traceback']
+    flags = ['-traceback']
 endif
 add_global_arguments(flags, language : 'fortran')
 

--- a/src/ErrorHandler.f90
+++ b/src/ErrorHandler.f90
@@ -67,18 +67,22 @@ module ErrorHandlerModule
                         printErrorCode, &
                         triggerWarnings, &
                         on)
-            class(ErrorHandler), intent(inout)          :: this             !! This ErrorHandler instance
-            type(ErrorInstance), intent(in), optional   :: errors(:)        !! List of ErrorInstances to add
-            character(len=*), intent(in), optional      :: criticalPrefix   !! Prefix for error messages if they're critical
-            character(len=*), intent(in), optional      :: warningPrefix    !! Prefix for error messages if they're warnings
-            character(len=*), intent(in), optional      :: messageSuffix    !! Suffix for error messages
-            logical, intent(in), optional               :: bashColors       !! Use bash colours or not?
-            logical, intent(in), optional               :: printErrorCode   !! Should the error code be prepended to the prefix?
-            logical, intent(in), optional               :: triggerWarnings  !! Should warnings be printed on trigger?
-            logical, intent(in), optional               :: on               !! Turn the ErrorHandler on or off
-            integer                                     :: i                ! Loop iterator.
-            logical, allocatable                        :: mask(:)          ! Logical mask to remove default errors from input errors array.
-            type(ErrorInstance)                         :: defaultErrors(2) ! Temporary array containing default errors.
+            class(ErrorHandler), intent(inout)          :: this                     !! This ErrorHandler instance
+            type(ErrorInstance), intent(in), optional   :: errors(:)                !! List of ErrorInstances to add
+            character(len=*), intent(in), optional      :: criticalPrefix           !! Prefix for error messages if they're critical
+            character(len=*), intent(in), optional      :: warningPrefix            !! Prefix for error messages if they're warnings
+            character(len=*), intent(in), optional      :: messageSuffix            !! Suffix for error messages
+            logical, intent(in), optional               :: bashColors               !! Use bash colours or not?
+            logical, intent(in), optional               :: printErrorCode           !! Should the error code be prepended to the prefix?
+            logical, intent(in), optional               :: triggerWarnings          !! Should warnings be printed on trigger?
+            logical, intent(in), optional               :: on                       !! Turn the ErrorHandler on or off
+            integer                                     :: i                        ! Loop iterator.
+            logical, allocatable                        :: mask(:)                  ! Logical mask to remove default errors from input errors array.
+            type(ErrorInstance)                         :: defaultErrors(2)         ! Temporary array containing default errors.
+            character(len=*), parameter                 :: ESC = char(27)           ! Terminal escape character
+            character(len=*), parameter                 :: COLOR_RED = ESC//"[91m"  ! Escape sequence for red text
+            character(len=*), parameter                 :: COLOR_BLUE = ESC//"[94m" ! Escape sequence for blue text
+            character(len=*), parameter                 :: COLOR_RESET = ESC//"[0m" ! Escape sequence to reset text color
 
             ! Stop the program running is ErrorHandler is already initialised
             call this%stopIfInitialised()
@@ -137,8 +141,8 @@ module ErrorHandlerModule
 
             ! Set whether bash colors wanted or not, and add them to prefixes if so
             if (present(bashColors)) this%bashColors = bashColors
-            if (this%bashColors .eqv. .true.) this%criticalPrefix = "\x1B[91m" // adjustl(trim(this%criticalPrefix)) // "\x1B[0m"
-            if (this%bashColors .eqv. .true.) this%warningPrefix = "\x1B[94m" // adjustl(trim(this%warningPrefix)) // "\x1B[0m"
+            if (this%bashColors .eqv. .true.) this%criticalPrefix = COLOR_RED // adjustl(trim(this%criticalPrefix)) // COLOR_RESET
+            if (this%bashColors .eqv. .true.) this%warningPrefix = COLOR_BLUE // adjustl(trim(this%warningPrefix)) // COLOR_RESET
 
             ! Set whether we want the error code to be prefixed to the message and whether
             ! we want warnings to be triggered


### PR DESCRIPTION
The ANSI terminal escape character (0x1B) is now hardcoded as `char(27)` instead of relying on C-Style escape sequences in character strings. This means you don't need to compile with `-fbackslash`.